### PR TITLE
Enable response compression (Brotli + Gzip Optimal)

### DIFF
--- a/Nebula.API/Startup.cs
+++ b/Nebula.API/Startup.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,8 @@ using NetTopologySuite.IO.Converters;
 using SendGrid;
 using Serilog;
 using System;
+using System.IO.Compression;
+using System.Linq;
 using System.Text.Json.Serialization;
 using ILogger = Serilog.ILogger;
 
@@ -49,6 +52,16 @@ namespace Nebula.API
                 opt.JsonSerializerOptions.NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals;
                 opt.JsonSerializerOptions.WriteIndented = true;
             });
+
+            services.AddResponseCompression(options =>
+            {
+                options.EnableForHttps = true;
+                options.Providers.Add<BrotliCompressionProvider>();
+                options.Providers.Add<GzipCompressionProvider>();
+                options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[] { "application/json" });
+            });
+            services.Configure<BrotliCompressionProviderOptions>(options => options.Level = CompressionLevel.Optimal);
+            services.Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.Optimal);
 
             services.Configure<NebulaConfiguration>(Configuration);
 
@@ -115,6 +128,7 @@ namespace Nebula.API
             }
 
             app.UseHttpsRedirection();
+            app.UseResponseCompression();
             app.UseRouting();
             app.UseCors(policy =>
             {


### PR DESCRIPTION
## Summary
- Adds `Microsoft.AspNetCore.ResponseCompression` to `Nebula.API`
- Brotli + Gzip providers (browsers prefer Brotli; Gzip is the universal fallback)
- Compression level set to `Optimal` — small server CPU cost for ~30% smaller output vs `Fastest`

Cribbed from the same change on Qanat ([esassoc/qanat@753b0b7](https://github.com/esassoc/qanat/commit/753b0b70986667637b3c2776773496381599317b)), which measured ~10× smaller JSON payloads on the worst-case page. Production gains scale with network bandwidth savings on every endpoint with a non-trivial response and should also cut Azure egress costs.

## Test plan
- [ ] Smoke-test a heavy endpoint locally and confirm `Content-Encoding: br` (or `gzip`) on the response
- [ ] Verify swagger UI and health checks still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)