### PR TITLE
Pass the required projectName parameter to docker-template

### DIFF
--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -103,6 +103,7 @@ stages:
 
     - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates 
       parameters:
+        projectName: 'nebula'
         displayName: 'API'
         subscription: '$(azureSubscription)'
         containerRegistry: '$(kv-containerRegistry)'
@@ -132,6 +133,7 @@ stages:
 
     - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates 
       parameters:
+        projectName: 'nebula'
         displayName: 'Web'
         subscription: '$(azureSubscription)'
         containerRegistry: '$(kv-containerRegistry)'


### PR DESCRIPTION
Fixes the QA deploy failure: **"A value for the 'projectName' parameter must be provided."**

`docker-template.yml@BuildTemplates` declares `projectName` with no default, so it is mandatory. Nebula's two calls — BuildAPI and BuildWeb — never passed it.

## Not a regression

The pre-merge pipeline at `fc799ce` has **zero** occurrences of `projectName` too, so this predates the .NET 10 / passwordless work. Nebula references `@BuildTemplates` **unpinned**, which resolves to that repo's default branch; `docker-template` gained the required parameter upstream in `8ffe268` ("switch all to v2", 2024-07-08), and nebula has not deployed since.

## The value

Every sibling app passes the lowercase app name:

```
wave-runup   projectName: 'waverunup'
neptune      projectName: 'neptune'
qanat        projectName: 'qanat'
```

So `'nebula'`.

## Swept for the same class of failure

Rather than fix only the reported error, I compared **every** `@BuildTemplates` call in both pipelines against each template's required parameters (those with no `default:`, read from `origin/master`):

| Template | |
|---|---|
| `docker-template` ×2 | ❌ → fixed |
| `dacpac-template`, `terraform` ×2, `db-deploy-template`, `db-user`, `db-aad-user`, `update-jira` ×4 | ✅ |

So this should be the only parameter gap standing between you and a green run.

## Underlying exposure, not fixed here

The unpinned `@BuildTemplates` reference means **any** required parameter added upstream breaks every consuming app at deploy time with no warning. Pinning to a ref or tag would fix that properly, but it's a change across all the apps rather than something to slip into a deploy hotfix.

Verified: pipeline YAML parses and all eight stages resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
