### PR TITLE
Fix login failure for returning Auth0 users

### DIFF
--- a/Nebula.API/Controllers/UserController.cs
+++ b/Nebula.API/Controllers/UserController.cs
@@ -32,8 +32,11 @@ namespace Nebula.API.Controllers
             // Access claims via the User property instead of injecting ClaimsPrincipal
             var claims = User;
             
-            var globalID = claims.Claims.Single(c => c.Type == ClaimTypes.NameIdentifier).Value;
-            var email = claims.Claims.Single(c => c.Type == ClaimTypes.Email).Value;
+            // FirstOrDefault, not Single: .Single() threw before the guard below could
+            // run, so the intended 400 was unreachable and a missing or duplicated
+            // claim surfaced as a 500 instead.
+            var globalID = claims.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
+            var email = claims.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value;
             if (string.IsNullOrWhiteSpace(globalID) || string.IsNullOrWhiteSpace(email))
             {
                 return BadRequest();

--- a/Nebula.EFModels/Entities/User.cs
+++ b/Nebula.EFModels/Entities/User.cs
@@ -182,12 +182,36 @@ namespace Nebula.EFModels.Entities
                 .Single(x => x.UserID == userID);
 
             user.GlobalUserID = globalID;
-            user.LoginName = claims.Claims.Single(c => c.Type == "nickname").Value;
-            user.Email = claims.Claims.Single(c => c.Type == ClaimTypes.Email).Value;
             user.LastActivityDate = DateTime.UtcNow;
 
-            var firstName = claims?.Claims.SingleOrDefault(c => c.Type == ClaimsConstants.GivenName)?.Value;
-            var lastName = claims?.Claims.SingleOrDefault(c => c.Type == ClaimsConstants.FamilyName)?.Value;
+            // Every claim read is optional and every assignment guarded, matching
+            // Neptune's People.UpdateClaims. Previously LoginName and Email used
+            // .Single(), which throws when a claim is absent -- so a returning user
+            // 500'd on /user-claims while a first-time user succeeded, because the
+            // create path in UserController already tolerated a missing nickname.
+            //
+            // FirstOrDefault rather than SingleOrDefault: the latter still throws on
+            // DUPLICATE claims, which is reachable when an Auth0 action sets a custom
+            // claim that ASP.NET's inbound mapping also produces.
+            var email = claims?.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value;
+            var loginName = claims?.Claims.FirstOrDefault(c => c.Type == "nickname")?.Value;
+            var firstName = claims?.Claims.FirstOrDefault(c => c.Type == ClaimsConstants.GivenName)?.Value;
+            var lastName = claims?.Claims.FirstOrDefault(c => c.Type == ClaimsConstants.FamilyName)?.Value;
+
+            if (!string.IsNullOrWhiteSpace(email))
+            {
+                user.Email = email;
+            }
+            // LoginName falls back to email, the same fallback the create path uses.
+            // Assigned after Email so it picks up a freshly updated address.
+            if (!string.IsNullOrWhiteSpace(loginName))
+            {
+                user.LoginName = loginName;
+            }
+            else if (string.IsNullOrWhiteSpace(user.LoginName))
+            {
+                user.LoginName = user.Email;
+            }
             if (!string.IsNullOrWhiteSpace(firstName))
             {
                 user.FirstName = firstName;

--- a/Nebula.Web/src/app/services/authentication.service.ts
+++ b/Nebula.Web/src/app/services/authentication.service.ts
@@ -46,6 +46,13 @@ export class AuthenticationService {
           return this.userService.userClaimsPost().pipe(
             catchError((error) => {
               console.error("Failed to load user claims:", error);
+              // Auth0 authenticated us, but without an app account there is no
+              // usable session -- so report unauthenticated rather than leave
+              // hasClaims true with a null currentUser, which showed the
+              // signed-in header (Welcome / Sign Out) with a blank name.
+              // The route guards already keyed off currentUser, so access
+              // control was never affected; this only realigns the chrome.
+              this.hasClaims = false;
               this.alertService.pushAlert(new Alert(
                 "We could not load your account. Please try signing in again, or contact support if this continues.",
                 AlertContext.Danger));

--- a/Nebula.Web/src/app/services/authentication.service.ts
+++ b/Nebula.Web/src/app/services/authentication.service.ts
@@ -5,7 +5,7 @@ import { AlertService } from '../shared/services/alert.service';
 import { Alert } from '../shared/models/alert';
 import { AlertContext } from '../shared/models/enums/alert-context.enum';
 import { Observable, of } from "rxjs";
-import { switchMap, } from "rxjs/operators";
+import { catchError, switchMap, } from "rxjs/operators";
 import { UserDto, UserService } from '../shared/generated';
 import { Router } from "@angular/router";
 import { RoleEnum } from "../shared/generated/enum/role-enum";
@@ -39,7 +39,19 @@ export class AuthenticationService {
             return of(null);
           }
           this.hasClaims = true;
-          return this.userService.userClaimsPost();
+          // catchError INSIDE the switchMap: an error here would otherwise
+          // terminate the outer idTokenClaims$ subscription for the lifetime of
+          // the page, so a single failed /user-claims call left the app with no
+          // user and no message -- which is how a 500 on this endpoint presented.
+          return this.userService.userClaimsPost().pipe(
+            catchError((error) => {
+              console.error("Failed to load user claims:", error);
+              this.alertService.pushAlert(new Alert(
+                "We could not load your account. Please try signing in again, or contact support if this continues.",
+                AlertContext.Danger));
+              return of(null);
+            }),
+          );
         }),
       ).subscribe(
         (user) => {


### PR DESCRIPTION
Returning users fail on `POST /user-claims`; first-time users succeed.

## Root cause

The two paths disagree about whether claims are optional:

```csharp
// UserController.cs:70 — NEW user
var loginName = claims?.Claims.SingleOrDefault(c => c.Type == "nickname")?.Value;
LoginName = loginName ?? email,            // tolerates absence

// User.cs:185 — RETURNING user
user.LoginName = claims.Claims.Single(c => c.Type == "nickname").Value;   // THROWS
```

`.Single()` throws when a claim is absent, so any token without `nickname` 500s — **but only on the returning-user path**, which is exactly the reported symptom.

`nickname` isn't a claim the API can rely on. It validates the **JWT bearer — the access token** — and standard OIDC profile claims live in the **ID token** unless an Auth0 action explicitly copies them across.

## Fix

Reworked `UpdateClaims` to match **Neptune's `People.UpdateClaims`**: every claim read optional, every assignment guarded, so a missing claim leaves the stored value alone rather than throwing or nulling it. `LoginName` falls back to `Email` — the same fallback the create path already used — and is assigned after `Email` so it picks up a freshly updated address.

One deliberate deviation from Neptune: **`FirstOrDefault` rather than `SingleOrDefault`**. The latter still throws on *duplicate* claims, which is reachable when an Auth0 action sets a custom claim that ASP.NET's inbound mapping also produces — precisely the shape of the `email` / `given_name` / `family_name` action being introduced.

## Two related defects fixed

**`UserController` had unreachable error handling.** `.Single()` on `globalID`/`email` ran *before* the `IsNullOrWhiteSpace` guard immediately below it, so the intended `400` could never be returned and a missing claim surfaced as a `500`. Now `FirstOrDefault`, which lets that guard work.

**The frontend caught nothing.** `AuthenticationService` had no error handler around `userClaimsPost()`, so an error terminated the outer `idTokenClaims$` subscription for the lifetime of the page — no user, no message, no recovery without a reload. That's why this presented as a silent hang instead of an error. `catchError` now sits **inside** the `switchMap` so the outer stream survives and the user sees an alert.

## No Auth0 action change needed

With `LoginName` falling back to email, `nickname` no longer needs to be in the access token. The proposed action is still fine to deploy for the `email` / `given_name` / `family_name` claims — it just isn't required by this fix, and on its own it would **not** have resolved this, since it doesn't set `nickname`.

## Verification

Nebula.EFModels, Nebula.API and the web build are all clean. **Not verified end-to-end against Auth0** — that needs the deployed QA environment. The diagnosis is from code analysis plus your confirmation that returning users specifically are the ones failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
