### PR TITLE
Fix Add buttons staying disabled after submit (zoneless regression)

### DIFF
--- a/Nebula.Web/src/app/pages/diversion-scenario/diversion-scenario.component.ts
+++ b/Nebula.Web/src/app/pages/diversion-scenario/diversion-scenario.component.ts
@@ -305,6 +305,10 @@ export class DiversionScenarioComponent implements OnInit {
   }
 
   public removeVariableFromSelection(): void {
+    // This page holds at most one variable, so removing means emptying it.
+    // Previously selected-data-card spliced the array in place; now the parent
+    // owns it.
+    this.selectedVariables.set([]);
     this.timeSeriesForm.patchValue({ site: null });
     this.lyraMessages.set([]);
     this.clearResults();

--- a/Nebula.Web/src/app/pages/paired-regression-analysis/paired-regression-analysis.component.ts
+++ b/Nebula.Web/src/app/pages/paired-regression-analysis/paired-regression-analysis.component.ts
@@ -189,17 +189,23 @@ export class PairedRegressionAnalysisComponent implements OnInit {
   }
 
   public addVariableToSelection(variable: SiteVariable): void {
+    // The parent owns selectedVariables. station-select-card used to push into
+    // this array in place, which a signal cannot observe -- so the Add buttons
+    // kept a stale enabled state until some other signal forced a re-render.
+    this.selectedVariables.update(v => [...v, variable]);
     this.addSiteVariableToQuery(variable);
     this.clearResults();
     this.cdr.detectChanges();
   }
 
   public removeVariableFromSelection(index: number): void {
+    this.selectedVariables.update(v => v.filter((_, i) => i !== index));
     this.removeSiteVariableToQuery(index);
     this.clearResults();
   }
 
   public clearAllVariables(): void {
+    this.selectedVariables.set([]);
     this.timeseries().clear();
     this.clearResults();
   }

--- a/Nebula.Web/src/app/pages/time-series-analysis/time-series-analysis.component.ts
+++ b/Nebula.Web/src/app/pages/time-series-analysis/time-series-analysis.component.ts
@@ -185,17 +185,23 @@ export class TimeSeriesAnalysisComponent implements OnInit {
   }
 
   public addVariableToSelection(variable: SiteVariable): void {
+    // The parent owns selectedVariables. station-select-card used to push into
+    // this array in place, which a signal cannot observe -- so the Add buttons
+    // kept a stale enabled state until some other signal forced a re-render.
+    this.selectedVariables.update(v => [...v, variable]);
     this.addSiteVariableToQuery(variable);
     this.clearResults();
     this.cdr.detectChanges();
   }
 
   public removeVariableFromSelection(index: number): void {
+    this.selectedVariables.update(v => v.filter((_, i) => i !== index));
     this.removeSiteVariableToQuery(index);
     this.clearResults();
   }
 
   public clearAllVariables(): void {
+    this.selectedVariables.set([]);
     this.timeseries().clear();
     this.clearResults();
   }

--- a/Nebula.Web/src/app/shared/components/selected-data-card/selected-data-card.component.ts
+++ b/Nebula.Web/src/app/shared/components/selected-data-card/selected-data-card.component.ts
@@ -33,16 +33,18 @@ export class SelectedDataCardComponent implements OnInit {
     this.selectStationOnMap.emit(variable.station);
   }
 
+  // Neither of these mutates this.selectedVariables. It is an @Input, and
+  // splicing it edited the parent's array in place -- invisible to a signal, so
+  // the parent never re-rendered and its predicates went stale. The parent owns
+  // the list and updates it from these events; the new value comes back through
+  // the input.
   public removeVariableFromSelection(index: number): void {
-    this.selectedVariables.splice(index, 1);
-    //Need to spread here to adequately trigger change detection
-    this.selectedVariablesChange.emit([...this.selectedVariables]);
+    this.selectedVariablesChange.emit(this.selectedVariables.filter((_, i) => i !== index));
     this.singleVariableRemoved.emit(index);
   }
 
   public clearAllVariables(): void {
-    this.selectedVariables = [];
-    this.selectedVariablesChange.emit(this.selectedVariables);
+    this.selectedVariablesChange.emit([]);
     this.allVariablesCleared.emit();
   }
 

--- a/Nebula.Web/src/app/shared/components/selected-data-card/selected-data-card.component.ts
+++ b/Nebula.Web/src/app/shared/components/selected-data-card/selected-data-card.component.ts
@@ -16,8 +16,6 @@ export class SelectedDataCardComponent implements OnInit {
   @Input()
   public headerText: string = 'Selected Data';
   @Output()
-  public selectedVariablesChange = new EventEmitter<SiteVariable[]>();
-  @Output()
   public singleVariableRemoved = new EventEmitter<number>();
   @Output()
   public allVariablesCleared = new EventEmitter();
@@ -39,12 +37,10 @@ export class SelectedDataCardComponent implements OnInit {
   // the list and updates it from these events; the new value comes back through
   // the input.
   public removeVariableFromSelection(index: number): void {
-    this.selectedVariablesChange.emit(this.selectedVariables.filter((_, i) => i !== index));
     this.singleVariableRemoved.emit(index);
   }
 
   public clearAllVariables(): void {
-    this.selectedVariablesChange.emit([]);
     this.allVariablesCleared.emit();
   }
 

--- a/Nebula.Web/src/app/shared/components/station-select-card/station-select-card.component.ts
+++ b/Nebula.Web/src/app/shared/components/station-select-card/station-select-card.component.ts
@@ -268,8 +268,12 @@ export class StationSelectCardComponent implements OnInit {
     // the parent never re-rendered and its disabled-state predicates went
     // stale. The parent owns the list and updates it from addingVariableEvent;
     // the new value arrives back through the input setter.
+    //
+    // No updateSelectedDataStationsLayer() call here either: the setter runs it
+    // when the new array arrives. Calling it now would redraw from the OLD
+    // list, because input propagation happens during change detection rather
+    // than synchronously inside this handler.
     this.addingVariableEvent.emit(variable);
-    this.updateSelectedDataStationsLayer();
   }
 
   public variablePresentInSelectedVariables(variable: SiteVariable): boolean {

--- a/Nebula.Web/src/app/shared/components/station-select-card/station-select-card.component.ts
+++ b/Nebula.Web/src/app/shared/components/station-select-card/station-select-card.component.ts
@@ -263,10 +263,13 @@ export class StationSelectCardComponent implements OnInit {
   }
 
   public addVariableToSelection(variable: SiteVariable): void {
-    this.selectedVariables.push(variable);
+    // Does NOT push into this.selectedVariables. That is an @Input, and pushing
+    // mutated the parent's array in place -- which a signal cannot observe, so
+    // the parent never re-rendered and its disabled-state predicates went
+    // stale. The parent owns the list and updates it from addingVariableEvent;
+    // the new value arrives back through the input setter.
     this.addingVariableEvent.emit(variable);
     this.updateSelectedDataStationsLayer();
-    this.cdr.detectChanges();
   }
 
   public variablePresentInSelectedVariables(variable: SiteVariable): boolean {


### PR DESCRIPTION
Adding data works the first time; after submitting once the Add buttons never re-enable. Reported on **diversion-scenario** and **paired-regression-analysis**.

**This is a regression from the signals conversion in #47.**

## Root cause

Two child components mutated the `selectedVariables` **@Input** in place:

```ts
station-select-card.addVariableToSelection    ->  this.selectedVariables.push(variable)
selected-data-card.removeVariableFromSelection ->  this.selectedVariables.splice(index, 1)
```

That array *is* the parent's signal value. A signal only notifies on **identity change**, so the parent never re-rendered. Under Zone this worked, because the click triggered change detection globally regardless.

## Why it looked fine until a submit

Nothing forced the parent to re-check, so its predicates kept rendering a **stale, enabled** state. Submitting sets `gettingTimeSeriesData`, which *does* notify — the parent finally re-checks and the real state surfaces. By then `selectedVariables` has grown, so:

```
paired-regression:  canSelectVariable()      = selectedVariables().length < 2
diversion-scenario: disableAddingVariable()  -> variablePresentInSelectedVariables()
```

both correctly report *disabled* — and stay that way.

**time-series-analysis escaped it** only because it binds `canAddDuplicateVariable="true"`, which short-circuits `disableAddingVariable` before the array is ever consulted. Its state was equally stale; the symptom just had nowhere to show. That's exactly why it was the one page that seemed fine.

## Fix

Children no longer touch the input. They emit; the parent owns the list, so every change goes through the signal.

- `station-select-card` emits `addingVariableEvent` only (its now-unnecessary `cdr.detectChanges()` goes too)
- `selected-data-card` emits a **new** array instead of splicing, and stops reassigning the input on clear
- All three parents update `selectedVariables` on add, remove and clear

## A gap this surfaced

**None of the parents' remove/clear handlers touched `selectedVariables` at all** — removal worked *only* via the card's in-place splice. With the splice gone they would have displayed removed variables forever. So add/remove/clear are now handled in each parent, and `diversion-scenario`'s remove empties the list to match its one-variable-at-a-time model.

## Verification

Build clean; no component mutates a `selectedVariables` input any more; the signal-invocation audit still reports clean.

**Not verified in a browser** — this needs the same click-through as the rest of the zoneless work. Worth testing specifically: add → remove → add again, and add → submit → add again, on all three pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
