### PR TITLE
Keep analysis date ranges inside the station's available record

### DIFF
--- a/Nebula.Web/src/app/pages/diversion-scenario/diversion-scenario.component.ts
+++ b/Nebula.Web/src/app/pages/diversion-scenario/diversion-scenario.component.ts
@@ -11,6 +11,7 @@ import { SiteFilterEnum } from 'src/app/shared/models/enums/site-filter.enum';
 import { HydstraWeatherCondition } from 'src/app/shared/models/hydstra/hydstra-weather-condition';
 import { SiteVariable } from 'src/app/shared/models/site-variable';
 import { AlertService } from 'src/app/shared/services/alert.service';
+import DateRangeHelpers from 'src/app/shared/helpers/date-range-helpers';
 import { DateTime } from 'luxon';
 import { CustomRichTextTypeEnum } from 'src/app/shared/generated/enum/custom-rich-text-type-enum';
 import { UserDto } from 'src/app/shared/generated';
@@ -297,8 +298,8 @@ export class DiversionScenarioComponent implements OnInit {
   }
 
   public addVariableToSelection(variable: SiteVariable): void {
-    this.selectedVariables.set([]);
-    this.selectedVariables.update(v => [...v, variable]);
+    this.selectedVariables.set([variable]);
+    this.clampDateRangeToVariableRecord(variable);
     this.timeSeriesForm.patchValue({ site: variable.station });
     this.timeSeriesForm.patchValue({ nearest_rainfall_station: variable.nearestRainfallStationInfo.station});
     this.clearResults();
@@ -491,5 +492,38 @@ export class DiversionScenarioComponent implements OnInit {
     }
 
     return row[column];
+  }
+
+  /**
+   * Keeps the requested window inside the record for the variable just added.
+   * Lyra 500s on a window containing no data, and that crash bypasses its CORS
+   * middleware, so the browser cannot read the reason -- the page would just
+   * fail silently. The default window is the last three months, which is
+   * entirely after the end of the record for any station whose data lags.
+   */
+  private clampDateRangeToVariableRecord(variable: SiteVariable): void {
+    if (!variable || !variable.periodStart || !variable.periodEnd) {
+      return;
+    }
+
+    const clamped = DateRangeHelpers.clampToAvailableRange(
+      this.getDateFromTimeSeriesFormDateObject('start_date'),
+      this.getDateFromTimeSeriesFormDateObject('end_date'),
+      variable.periodStart,
+      variable.periodEnd);
+
+    if (!clamped) {
+      return;
+    }
+
+    this.timeSeriesForm.patchValue({
+      start_date: this.formatDateForNgbDatepicker(clamped.start),
+      end_date: this.formatDateForNgbDatepicker(clamped.end),
+    });
+
+    const asIsoDate = (date: Date) => date.toISOString().slice(0, 10);
+    this.alertService.pushAlert(new Alert(
+      `${variable.name} has no data at this station for the dates you selected, so the range was changed to ${asIsoDate(clamped.start)} - ${asIsoDate(clamped.end)} (available record: ${variable.startDate} - ${variable.endDate}).`,
+      AlertContext.Info, true));
   }
 }

--- a/Nebula.Web/src/app/pages/diversion-scenario/diversion-scenario.component.ts
+++ b/Nebula.Web/src/app/pages/diversion-scenario/diversion-scenario.component.ts
@@ -299,7 +299,7 @@ export class DiversionScenarioComponent implements OnInit {
 
   public addVariableToSelection(variable: SiteVariable): void {
     this.selectedVariables.set([variable]);
-    this.clampDateRangeToVariableRecord(variable);
+    DateRangeHelpers.clampFormRangeToVariableRecord(this.timeSeriesForm, variable, this.alertService);
     this.timeSeriesForm.patchValue({ site: variable.station });
     this.timeSeriesForm.patchValue({ nearest_rainfall_station: variable.nearestRainfallStationInfo.station});
     this.clearResults();
@@ -494,36 +494,4 @@ export class DiversionScenarioComponent implements OnInit {
     return row[column];
   }
 
-  /**
-   * Keeps the requested window inside the record for the variable just added.
-   * Lyra 500s on a window containing no data, and that crash bypasses its CORS
-   * middleware, so the browser cannot read the reason -- the page would just
-   * fail silently. The default window is the last three months, which is
-   * entirely after the end of the record for any station whose data lags.
-   */
-  private clampDateRangeToVariableRecord(variable: SiteVariable): void {
-    if (!variable || !variable.periodStart || !variable.periodEnd) {
-      return;
-    }
-
-    const clamped = DateRangeHelpers.clampToAvailableRange(
-      this.getDateFromTimeSeriesFormDateObject('start_date'),
-      this.getDateFromTimeSeriesFormDateObject('end_date'),
-      variable.periodStart,
-      variable.periodEnd);
-
-    if (!clamped) {
-      return;
-    }
-
-    this.timeSeriesForm.patchValue({
-      start_date: this.formatDateForNgbDatepicker(clamped.start),
-      end_date: this.formatDateForNgbDatepicker(clamped.end),
-    });
-
-    const asIsoDate = (date: Date) => date.toISOString().slice(0, 10);
-    this.alertService.pushAlert(new Alert(
-      `${variable.name} has no data at this station for the dates you selected, so the range was changed to ${asIsoDate(clamped.start)} - ${asIsoDate(clamped.end)} (available record: ${variable.startDate} - ${variable.endDate}).`,
-      AlertContext.Info, true));
-  }
 }

--- a/Nebula.Web/src/app/pages/paired-regression-analysis/paired-regression-analysis.component.ts
+++ b/Nebula.Web/src/app/pages/paired-regression-analysis/paired-regression-analysis.component.ts
@@ -3,6 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { UntypedFormGroup, UntypedFormControl, Validators, UntypedFormArray, UntypedFormBuilder } from '@angular/forms';
 import { AuthenticationService } from 'src/app/services/authentication.service';
 import { LyraService } from 'src/app/services/lyra.service';
+import { AlertService } from 'src/app/shared/services/alert.service';
 import { Alert } from 'src/app/shared/models/alert';
 import { AlertContext } from 'src/app/shared/models/enums/alert-context.enum';
 import { HydstraAggregationMethod } from 'src/app/shared/models/hydstra/hydstra-aggregation-mode';
@@ -10,6 +11,7 @@ import { HydstraWeatherCondition } from 'src/app/shared/models/hydstra/hydstra-w
 import { HydstraInterval } from 'src/app/shared/models/hydstra/hydstra-interval';
 import { HydstraRegressionMethod } from 'src/app/shared/models/hydstra/hydstra-regression-method';
 import { SiteVariable } from 'src/app/shared/models/site-variable';
+import DateRangeHelpers from 'src/app/shared/helpers/date-range-helpers';
 import { ActivatedRoute } from '@angular/router';
 import { StationSelectCardComponent } from 'src/app/shared/components/station-select-card/station-select-card.component';
 import { DateTime } from 'luxon';
@@ -74,7 +76,8 @@ export class PairedRegressionAnalysisComponent implements OnInit {
     private lyraService: LyraService,
     private formBuilder: UntypedFormBuilder,
     private authenticationService: AuthenticationService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private alertService: AlertService
   ) {
   }
 
@@ -193,6 +196,7 @@ export class PairedRegressionAnalysisComponent implements OnInit {
     // this array in place, which a signal cannot observe -- so the Add buttons
     // kept a stale enabled state until some other signal forced a re-render.
     this.selectedVariables.update(v => [...v, variable]);
+    this.clampDateRangeToVariableRecord(variable);
     this.addSiteVariableToQuery(variable);
     this.clearResults();
     this.cdr.detectChanges();
@@ -358,4 +362,37 @@ export class PairedRegressionAnalysisComponent implements OnInit {
     toUpdate.patchValue({[key] : value});
   }
 
+
+  /**
+   * Keeps the requested window inside the record for the variable just added.
+   * Lyra 500s on a window containing no data, and that crash bypasses its CORS
+   * middleware, so the browser cannot read the reason -- the page would just
+   * fail silently. The default window is the last three months, which is
+   * entirely after the end of the record for any station whose data lags.
+   */
+  private clampDateRangeToVariableRecord(variable: SiteVariable): void {
+    if (!variable || !variable.periodStart || !variable.periodEnd) {
+      return;
+    }
+
+    const clamped = DateRangeHelpers.clampToAvailableRange(
+      this.getDateFromTimeSeriesFormDateObject('start_date'),
+      this.getDateFromTimeSeriesFormDateObject('end_date'),
+      variable.periodStart,
+      variable.periodEnd);
+
+    if (!clamped) {
+      return;
+    }
+
+    this.timeSeriesForm.patchValue({
+      start_date: this.formatDateForNgbDatepicker(clamped.start),
+      end_date: this.formatDateForNgbDatepicker(clamped.end),
+    });
+
+    const asIsoDate = (date: Date) => date.toISOString().slice(0, 10);
+    this.alertService.pushAlert(new Alert(
+      `${variable.name} has no data at this station for the dates you selected, so the range was changed to ${asIsoDate(clamped.start)} - ${asIsoDate(clamped.end)} (available record: ${variable.startDate} - ${variable.endDate}).`,
+      AlertContext.Info, true));
+  }
 }

--- a/Nebula.Web/src/app/pages/paired-regression-analysis/paired-regression-analysis.component.ts
+++ b/Nebula.Web/src/app/pages/paired-regression-analysis/paired-regression-analysis.component.ts
@@ -196,7 +196,7 @@ export class PairedRegressionAnalysisComponent implements OnInit {
     // this array in place, which a signal cannot observe -- so the Add buttons
     // kept a stale enabled state until some other signal forced a re-render.
     this.selectedVariables.update(v => [...v, variable]);
-    this.clampDateRangeToVariableRecord(variable);
+    DateRangeHelpers.clampFormRangeToVariableRecord(this.timeSeriesForm, variable, this.alertService);
     this.addSiteVariableToQuery(variable);
     this.clearResults();
     this.cdr.detectChanges();
@@ -363,36 +363,4 @@ export class PairedRegressionAnalysisComponent implements OnInit {
   }
 
 
-  /**
-   * Keeps the requested window inside the record for the variable just added.
-   * Lyra 500s on a window containing no data, and that crash bypasses its CORS
-   * middleware, so the browser cannot read the reason -- the page would just
-   * fail silently. The default window is the last three months, which is
-   * entirely after the end of the record for any station whose data lags.
-   */
-  private clampDateRangeToVariableRecord(variable: SiteVariable): void {
-    if (!variable || !variable.periodStart || !variable.periodEnd) {
-      return;
-    }
-
-    const clamped = DateRangeHelpers.clampToAvailableRange(
-      this.getDateFromTimeSeriesFormDateObject('start_date'),
-      this.getDateFromTimeSeriesFormDateObject('end_date'),
-      variable.periodStart,
-      variable.periodEnd);
-
-    if (!clamped) {
-      return;
-    }
-
-    this.timeSeriesForm.patchValue({
-      start_date: this.formatDateForNgbDatepicker(clamped.start),
-      end_date: this.formatDateForNgbDatepicker(clamped.end),
-    });
-
-    const asIsoDate = (date: Date) => date.toISOString().slice(0, 10);
-    this.alertService.pushAlert(new Alert(
-      `${variable.name} has no data at this station for the dates you selected, so the range was changed to ${asIsoDate(clamped.start)} - ${asIsoDate(clamped.end)} (available record: ${variable.startDate} - ${variable.endDate}).`,
-      AlertContext.Info, true));
-  }
 }

--- a/Nebula.Web/src/app/pages/time-series-analysis/time-series-analysis.component.ts
+++ b/Nebula.Web/src/app/pages/time-series-analysis/time-series-analysis.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnInit, ViewChild, ElementRef, ChangeDetectorRef, signal, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { LyraService } from 'src/app/services/lyra.service';
+import { AlertService } from 'src/app/shared/services/alert.service';
 import { UntypedFormGroup, UntypedFormControl, Validators, UntypedFormArray, UntypedFormBuilder } from '@angular/forms';
 import { SiteVariable } from 'src/app/shared/models/site-variable';
+import DateRangeHelpers from 'src/app/shared/helpers/date-range-helpers';
 import { Alert } from 'src/app/shared/models/alert';
 import { AlertContext } from 'src/app/shared/models/enums/alert-context.enum';
 import { HydstraAggregationMethod } from 'src/app/shared/models/hydstra/hydstra-aggregation-mode';
@@ -69,7 +71,8 @@ export class TimeSeriesAnalysisComponent implements OnInit {
     private lyraService: LyraService,
     private formBuilder: UntypedFormBuilder,
     private authenticationService: AuthenticationService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private alertService: AlertService
   ) {
   }
 
@@ -189,6 +192,7 @@ export class TimeSeriesAnalysisComponent implements OnInit {
     // this array in place, which a signal cannot observe -- so the Add buttons
     // kept a stale enabled state until some other signal forced a re-render.
     this.selectedVariables.update(v => [...v, variable]);
+    this.clampDateRangeToVariableRecord(variable);
     this.addSiteVariableToQuery(variable);
     this.clearResults();
     this.cdr.detectChanges();
@@ -357,5 +361,38 @@ export class TimeSeriesAnalysisComponent implements OnInit {
     }
 
     toUpdate.patchValue({ [key]: value });
+  }
+
+  /**
+   * Keeps the requested window inside the record for the variable just added.
+   * Lyra 500s on a window containing no data, and that crash bypasses its CORS
+   * middleware, so the browser cannot read the reason -- the page would just
+   * fail silently. The default window is the last three months, which is
+   * entirely after the end of the record for any station whose data lags.
+   */
+  private clampDateRangeToVariableRecord(variable: SiteVariable): void {
+    if (!variable || !variable.periodStart || !variable.periodEnd) {
+      return;
+    }
+
+    const clamped = DateRangeHelpers.clampToAvailableRange(
+      this.getDateFromTimeSeriesFormDateObject('start_date'),
+      this.getDateFromTimeSeriesFormDateObject('end_date'),
+      variable.periodStart,
+      variable.periodEnd);
+
+    if (!clamped) {
+      return;
+    }
+
+    this.timeSeriesForm.patchValue({
+      start_date: this.formatDateForNgbDatepicker(clamped.start),
+      end_date: this.formatDateForNgbDatepicker(clamped.end),
+    });
+
+    const asIsoDate = (date: Date) => date.toISOString().slice(0, 10);
+    this.alertService.pushAlert(new Alert(
+      `${variable.name} has no data at this station for the dates you selected, so the range was changed to ${asIsoDate(clamped.start)} - ${asIsoDate(clamped.end)} (available record: ${variable.startDate} - ${variable.endDate}).`,
+      AlertContext.Info, true));
   }
 }

--- a/Nebula.Web/src/app/pages/time-series-analysis/time-series-analysis.component.ts
+++ b/Nebula.Web/src/app/pages/time-series-analysis/time-series-analysis.component.ts
@@ -192,7 +192,7 @@ export class TimeSeriesAnalysisComponent implements OnInit {
     // this array in place, which a signal cannot observe -- so the Add buttons
     // kept a stale enabled state until some other signal forced a re-render.
     this.selectedVariables.update(v => [...v, variable]);
-    this.clampDateRangeToVariableRecord(variable);
+    DateRangeHelpers.clampFormRangeToVariableRecord(this.timeSeriesForm, variable, this.alertService);
     this.addSiteVariableToQuery(variable);
     this.clearResults();
     this.cdr.detectChanges();
@@ -363,36 +363,4 @@ export class TimeSeriesAnalysisComponent implements OnInit {
     toUpdate.patchValue({ [key]: value });
   }
 
-  /**
-   * Keeps the requested window inside the record for the variable just added.
-   * Lyra 500s on a window containing no data, and that crash bypasses its CORS
-   * middleware, so the browser cannot read the reason -- the page would just
-   * fail silently. The default window is the last three months, which is
-   * entirely after the end of the record for any station whose data lags.
-   */
-  private clampDateRangeToVariableRecord(variable: SiteVariable): void {
-    if (!variable || !variable.periodStart || !variable.periodEnd) {
-      return;
-    }
-
-    const clamped = DateRangeHelpers.clampToAvailableRange(
-      this.getDateFromTimeSeriesFormDateObject('start_date'),
-      this.getDateFromTimeSeriesFormDateObject('end_date'),
-      variable.periodStart,
-      variable.periodEnd);
-
-    if (!clamped) {
-      return;
-    }
-
-    this.timeSeriesForm.patchValue({
-      start_date: this.formatDateForNgbDatepicker(clamped.start),
-      end_date: this.formatDateForNgbDatepicker(clamped.end),
-    });
-
-    const asIsoDate = (date: Date) => date.toISOString().slice(0, 10);
-    this.alertService.pushAlert(new Alert(
-      `${variable.name} has no data at this station for the dates you selected, so the range was changed to ${asIsoDate(clamped.start)} - ${asIsoDate(clamped.end)} (available record: ${variable.startDate} - ${variable.endDate}).`,
-      AlertContext.Info, true));
-  }
 }

--- a/Nebula.Web/src/app/shared/components/station-select-card/station-select-card.component.ts
+++ b/Nebula.Web/src/app/shared/components/station-select-card/station-select-card.component.ts
@@ -14,6 +14,7 @@ import { NgbTypeaheadSelectItemEvent } from '@ng-bootstrap/ng-bootstrap';
 import { LyraService } from 'src/app/services/lyra.service';
 import './leaflet.topojson.js'
 import { WatershedService } from '../../generated';
+import DateRangeHelpers from 'src/app/shared/helpers/date-range-helpers';
 
 declare let $: any;
 
@@ -225,6 +226,8 @@ export class StationSelectCardComponent implements OnInit {
         variable: variableInfo.variable,
         startDate: new Date(`${variableInfo.period_start.slice(0, 4)}-${variableInfo.period_start.slice(4, 6)}-${variableInfo.period_start.slice(6, 8)}`).toLocaleDateString(),
         endDate: new Date(`${variableInfo.period_end.slice(0, 4)}-${variableInfo.period_end.slice(4, 6)}-${variableInfo.period_end.slice(6, 8)}`).toLocaleDateString(),
+        periodStart: DateRangeHelpers.periodToIso(variableInfo.period_start),
+        periodEnd: DateRangeHelpers.periodToIso(variableInfo.period_end),
         allowedAggregations: variableInfo.allowed_aggregations
       }), baseSiteVariable);
       availableVariables.push(siteVariable);
@@ -240,6 +243,8 @@ export class StationSelectCardComponent implements OnInit {
         gage: rainfallStationProperties.stname,
         startDate: new Date(`${rainfallInfo.period_start.slice(0, 4)}-${rainfallInfo.period_start.slice(4, 6)}-${rainfallInfo.period_start.slice(6, 8)}`).toLocaleDateString(),
         endDate: new Date(`${rainfallInfo.period_end.slice(0, 4)}-${rainfallInfo.period_end.slice(4, 6)}-${rainfallInfo.period_end.slice(6, 8)}`).toLocaleDateString(),
+        periodStart: DateRangeHelpers.periodToIso(rainfallInfo.period_start),
+        periodEnd: DateRangeHelpers.periodToIso(rainfallInfo.period_end),
         allowedAggregations: rainfallInfo.allowed_aggregations,
         stationShortName: rainfallStationProperties.shortname,
         station: rainfallStationProperties.station

--- a/Nebula.Web/src/app/shared/helpers/date-range-helpers.ts
+++ b/Nebula.Web/src/app/shared/helpers/date-range-helpers.ts
@@ -1,3 +1,16 @@
+import { UntypedFormGroup } from '@angular/forms';
+import { SiteVariable } from '../models/site-variable';
+import { Alert } from '../models/alert';
+import { AlertContext } from '../models/enums/alert-context.enum';
+import { AlertService } from '../services/alert.service';
+
+/** The {year, month, day} shape ngb-datepicker form controls hold. */
+export interface NgbDateStruct {
+  year: number;
+  month: number;
+  day: number;
+}
+
 /**
  * Keeps requested analysis windows inside the period a station actually has
  * data for.
@@ -12,19 +25,32 @@
  */
 export default class DateRangeHelpers {
   /** Lyra returns period bounds as YYYYMMDD; convert to YYYY-MM-DD. */
-  public static periodToIso(period: string): string {
+  public static periodToIso(period?: string): string | null {
     if (!period || period.length < 8) {
       return null;
     }
     return `${period.slice(0, 4)}-${period.slice(4, 6)}-${period.slice(6, 8)}`;
   }
 
-  private static utc(iso: string): Date {
+  private static utc(iso: string): Date | null {
     return iso ? new Date(`${iso}T00:00:00Z`) : null;
   }
 
   private static addDaysUtc(date: Date, days: number): Date {
     return new Date(date.getTime() + days * 86400000);
+  }
+
+  /** ngb-datepicker struct -> YYYY-MM-DD. */
+  public static structToIso(value: NgbDateStruct): string | null {
+    if (!value || !value.year) {
+      return null;
+    }
+    return `${value.year}-${value.month.toString().padStart(2, '0')}-${value.day.toString().padStart(2, '0')}`;
+  }
+
+  /** Date -> ngb-datepicker struct. UTC getters: the dates are built as UTC. */
+  public static dateToStruct(date: Date): NgbDateStruct {
+    return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate() };
   }
 
   /**
@@ -37,7 +63,7 @@ export default class DateRangeHelpers {
    */
   public static clampToAvailableRange(
     startIso: string, endIso: string,
-    periodStartIso: string, periodEndIso: string): { start: Date, end: Date } {
+    periodStartIso: string, periodEndIso: string): { start: Date, end: Date } | null {
 
     const start = this.utc(startIso);
     const end = this.utc(endIso);
@@ -62,5 +88,43 @@ export default class DateRangeHelpers {
       start: newStart < periodStart ? periodStart : newStart,
       end: periodEnd,
     };
+  }
+
+  /**
+   * Moves a page's start_date/end_date controls inside the record for the
+   * variable just added, and tells the user when it does.
+   *
+   * Lives here rather than in each page so the clamp rule and the wording stay
+   * in one place -- all three analysis pages share the same form control names
+   * and the same failure.
+   */
+  public static clampFormRangeToVariableRecord(
+    form: UntypedFormGroup, variable: SiteVariable, alertService: AlertService): void {
+
+    if (!form || !variable || !variable.periodStart || !variable.periodEnd) {
+      return;
+    }
+
+    const clamped = this.clampToAvailableRange(
+      this.structToIso(form.get('start_date')?.value),
+      this.structToIso(form.get('end_date')?.value),
+      variable.periodStart,
+      variable.periodEnd);
+
+    if (!clamped) {
+      return;
+    }
+
+    form.patchValue({
+      start_date: this.dateToStruct(clamped.start),
+      end_date: this.dateToStruct(clamped.end),
+    });
+
+    const asIsoDate = (date: Date) => date.toISOString().slice(0, 10);
+    alertService.pushAlert(new Alert(
+      `${variable.name} has no data at this station for the dates you selected, so the range was ` +
+      `changed to ${asIsoDate(clamped.start)} - ${asIsoDate(clamped.end)} ` +
+      `(available record: ${variable.startDate} - ${variable.endDate}).`,
+      AlertContext.Info, true));
   }
 }

--- a/Nebula.Web/src/app/shared/helpers/date-range-helpers.ts
+++ b/Nebula.Web/src/app/shared/helpers/date-range-helpers.ts
@@ -1,0 +1,66 @@
+/**
+ * Keeps requested analysis windows inside the period a station actually has
+ * data for.
+ *
+ * Lyra returns 500 Internal Server Error (not a clean "no data" response) when
+ * a window contains no observations, and because that unhandled exception
+ * bypasses its CORS middleware the browser reports it as a CORS failure with an
+ * unreadable body -- so the app cannot even surface the reason. The pages
+ * default their window to the last three months, which is entirely after the
+ * end of the record for any station whose data lags, making that crash the
+ * default experience rather than an edge case.
+ */
+export default class DateRangeHelpers {
+  /** Lyra returns period bounds as YYYYMMDD; convert to YYYY-MM-DD. */
+  public static periodToIso(period: string): string {
+    if (!period || period.length < 8) {
+      return null;
+    }
+    return `${period.slice(0, 4)}-${period.slice(4, 6)}-${period.slice(6, 8)}`;
+  }
+
+  private static utc(iso: string): Date {
+    return iso ? new Date(`${iso}T00:00:00Z`) : null;
+  }
+
+  private static addDaysUtc(date: Date, days: number): Date {
+    return new Date(date.getTime() + days * 86400000);
+  }
+
+  /**
+   * Returns a window shifted inside [periodStart, periodEnd], or null when the
+   * requested window already overlaps the record and needs no adjustment.
+   *
+   * Any overlap is left alone: a partially-covered window still returns data,
+   * and silently moving a range the user chose deliberately would be worse than
+   * showing them a short result.
+   */
+  public static clampToAvailableRange(
+    startIso: string, endIso: string,
+    periodStartIso: string, periodEndIso: string): { start: Date, end: Date } {
+
+    const start = this.utc(startIso);
+    const end = this.utc(endIso);
+    const periodStart = this.utc(periodStartIso);
+    const periodEnd = this.utc(periodEndIso);
+
+    if (!start || !end || !periodStart || !periodEnd) {
+      return null;
+    }
+
+    // Overlap test: nothing to do unless the window sits entirely outside.
+    if (start <= periodEnd && end >= periodStart) {
+      return null;
+    }
+
+    // Preserve the span the user asked for, anchored to the end of the record,
+    // which is the part of the data people almost always want.
+    const spanDays = Math.max(1, Math.round((end.getTime() - start.getTime()) / 86400000));
+    const newStart = this.addDaysUtc(periodEnd, -spanDays);
+
+    return {
+      start: newStart < periodStart ? periodStart : newStart,
+      end: periodEnd,
+    };
+  }
+}

--- a/Nebula.Web/src/app/shared/models/site-variable.ts
+++ b/Nebula.Web/src/app/shared/models/site-variable.ts
@@ -6,13 +6,15 @@ export class SiteVariable {
   stationShortName: string;
   stationLongName: string;
   station: string;
-  // Display-only: these hold toLocaleDateString() output, not Date objects.
-  startDate: Date;
-  endDate: Date;
-  // Machine-readable record bounds (YYYY-MM-DD) used to keep requested windows
-  // inside the data Lyra actually has.
-  periodStart: string;
-  periodEnd: string;
+  // Display only. These are assigned toLocaleDateString() output, so they were
+  // typed Date while holding strings -- Date APIs on them compiled and then
+  // failed at runtime. Typed honestly; use periodStart/periodEnd for logic.
+  startDate: string;
+  endDate: string;
+  // Machine-readable record bounds (YYYY-MM-DD). Null when Lyra omits or
+  // malforms the period, which DateRangeHelpers.periodToIso reports as null.
+  periodStart: string | null;
+  periodEnd: string | null;
   nearestRainfallStationInfo: SiteVariable;
   allowedAggregations: string[];
 

--- a/Nebula.Web/src/app/shared/models/site-variable.ts
+++ b/Nebula.Web/src/app/shared/models/site-variable.ts
@@ -6,8 +6,13 @@ export class SiteVariable {
   stationShortName: string;
   stationLongName: string;
   station: string;
+  // Display-only: these hold toLocaleDateString() output, not Date objects.
   startDate: Date;
   endDate: Date;
+  // Machine-readable record bounds (YYYY-MM-DD) used to keep requested windows
+  // inside the data Lyra actually has.
+  periodStart: string;
+  periodEnd: string;
   nearestRainfallStationInfo: SiteVariable;
   allowedAggregations: string[];
 


### PR DESCRIPTION
The diversion-scenario page failed with what looked like a CORS error. **It wasn't.**

## What's actually happening

Lyra returns `500 Internal Server Error` when the requested window contains no observations. That unhandled exception **bypasses its CORS middleware**, so the response carries no `Access-Control-Allow-Origin`, and the browser reports a CORS failure with an unreadable body. Nebula's error handler therefore never sees `error.error.detail` and shows no banner — the page just fails silently.

Reproduced directly against Lyra, where browser CORS doesn't apply:

```
2026-05-14 .. 2026-08-14  (page default)   500,  21 bytes
2025-05-14 .. 2025-08-14                   200, 989 KB
2025-11-01 .. 2026-01-31                   200, 984 KB
```

Same station, same parameters — only the dates differ. All-zero form values were ruled out first; non-zero rate/storage/infiltration still 500'd.

The reported station has Discharge through **2026-02-03**, while the pages default to the last three months — so the default window sits **entirely after the end of the record**. For any station whose data lags a few months, that crash is the *default* experience, not an edge case.

## Fix

The pages already display the record (*"Record: 10/6/2020 - 2/3/2026"*) but never used it.

`SiteVariable` now carries machine-readable `periodStart` / `periodEnd`. The existing `startDate`/`endDate` are typed `Date` but actually hold `toLocaleDateString()` **strings**, so they're display-only and unsafe to parse back — worth knowing if you touch that model.

When a variable is added and the current window lies entirely outside its record, the window moves to the end of the available data, preserving the requested span, and an alert explains what changed.

**Any overlap is deliberately left alone.** A partially covered window still returns data, and silently rewriting a range the user chose would be worse than a short result.

## Verification

Clamp logic unit-checked across after / before / overlapping / straddling / shorter-than-record cases, and **end-to-end against Lyra**: the window it produces for the reported case (`2025-11-03 .. 2026-02-03`) returns **200** where the original returned **500**.

Build clean; signal audit still clean.

## Two Lyra-side defects worth reporting separately

1. An empty dataset should return a clean error, not an unhandled exception
2. That exception skipping the CORS middleware is what makes it undiagnosable from the browser — it also explains yesterday's `'NoneType' object is not iterable` on paired-regression

This PR works around both, but neither is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
