### PR TITLE
Apply ESLint autofixes

### DIFF
--- a/Nebula.Web/src/app/app-routing.module.ts
+++ b/Nebula.Web/src/app/app-routing.module.ts
@@ -23,7 +23,7 @@ import { CustomPageCreateComponent } from './pages/custom-page-create/custom-pag
 import { CustomPageEditPropertiesComponent } from './pages/custom-page-edit-properties/custom-page-edit-properties.component';
 import { CustomPageDetailComponent } from './pages/custom-page-detail/custom-page-detail.component';
 import { CustomPageAccessGuard } from './shared/guards/custom-page-access-guard';
-import { authGuardFn } from "@auth0/auth0-angular";
+import { authGuardFn } from '@auth0/auth0-angular';
 
 const routes: Routes = [
   { path: 'labels-and-definitions/:id', component: FieldDefinitionEditComponent, canActivate: [authGuardFn, ManagerOnlyGuard, AcknowledgedDisclaimerGuard] },

--- a/Nebula.Web/src/app/app.component.ts
+++ b/Nebula.Web/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, DOCUMENT, DestroyRef, inject } from '@angular/core';
+import { Component, Inject, DOCUMENT, DestroyRef, inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, RouteConfigLoadStart, RouteConfigLoadEnd, NavigationEnd } from '@angular/router';
 import { BusyService } from './shared/services';
@@ -10,7 +10,7 @@ import { Title } from '@angular/platform-browser';
   styleUrls: ['./app.component.scss'],
   standalone: false
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   constructor(

--- a/Nebula.Web/src/app/app.module.ts
+++ b/Nebula.Web/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule, APP_INITIALIZER, ErrorHandler, importProvidersFrom } from '@angular/core';
-import { provideHttpClient, withInterceptors, withXhr } from "@angular/common/http";
+import { provideHttpClient, withInterceptors, withXhr } from '@angular/common/http';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { SharedModule } from './shared/shared.module';
@@ -35,7 +35,7 @@ import { CustomPageEditPropertiesComponent } from './pages/custom-page-edit-prop
 import { ApiModule, Configuration } from './shared/generated';
 import { ModuleRegistry } from 'ag-grid-community';
 import { AllCommunityModule } from 'ag-grid-community';
-import { AuthClientConfig, authHttpInterceptorFn, AuthModule, provideAuth0 } from "@auth0/auth0-angular";
+import { AuthClientConfig, authHttpInterceptorFn, AuthModule, provideAuth0 } from '@auth0/auth0-angular';
 import { getAuthConfig } from './auth-config';
 
 export function init_app(authClientConfig: AuthClientConfig) {

--- a/Nebula.Web/src/app/auth-config.ts
+++ b/Nebula.Web/src/app/auth-config.ts
@@ -1,8 +1,8 @@
-import { environment } from "src/environments/environment";
+import { environment } from 'src/environments/environment';
 
 const authExcludedApiRoutePrefixes = ['public/'];
 
-export function getAuthConfig(): import("@auth0/auth0-angular").AuthConfig {
+export function getAuthConfig(): import('@auth0/auth0-angular').AuthConfig {
   return {
     domain: environment.auth0Configuration.domain,
     clientId: environment.auth0Configuration.clientId,
@@ -11,7 +11,7 @@ export function getAuthConfig(): import("@auth0/auth0-angular").AuthConfig {
     authorizationParams: {
       redirect_uri: window.location.origin,
       audience: environment.auth0Configuration.audience,
-      scope: "openid profile email offline_access",
+      scope: 'openid profile email offline_access',
     },
     httpInterceptor: {
       allowedList: [

--- a/Nebula.Web/src/app/pages/custom-page-create/custom-page-create.component.ts
+++ b/Nebula.Web/src/app/pages/custom-page-create/custom-page-create.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit, signal, inject, DestroyRef 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { AuthenticationService } from 'src/app/services/authentication.service';
-import { CustomPageService, CustomPageUpsertDto, MenuItemDto, MenuItemService, RoleDto, RoleService, UserDto } from 'src/app/shared/generated';
+import { CustomPageService, CustomPageUpsertDto, MenuItemDto, MenuItemService, RoleDto, RoleService } from 'src/app/shared/generated';
 import { RoleEnum } from 'src/app/shared/generated/enum/role-enum';
 import { Alert } from 'src/app/shared/models/alert';
 import { AlertContext } from 'src/app/shared/models/enums/alert-context.enum';

--- a/Nebula.Web/src/app/pages/custom-page-detail/custom-page-detail.component.ts
+++ b/Nebula.Web/src/app/pages/custom-page-detail/custom-page-detail.component.ts
@@ -5,7 +5,7 @@ import { AuthenticationService } from 'src/app/services/authentication.service';
 import { Alert } from 'src/app/shared/models/alert';
 import { AlertContext } from 'src/app/shared/models/enums/alert-context.enum';
 import { AlertService } from 'src/app/shared/services/alert.service';
-import { CustomPageDto, CustomPageService, CustomPageUpsertDto, UserDto } from 'src/app/shared/generated';
+import { CustomPageDto, CustomPageService, CustomPageUpsertDto } from 'src/app/shared/generated';
 import { EditorComponent } from '@tinymce/tinymce-angular';
 import TinyMCEHelpers from 'src/app/shared/helpers/tiny-mce-helpers';
 

--- a/Nebula.Web/src/app/pages/custom-page-edit-properties/custom-page-edit-properties.component.ts
+++ b/Nebula.Web/src/app/pages/custom-page-edit-properties/custom-page-edit-properties.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, signal, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthenticationService } from 'src/app/services/authentication.service';
-import { CustomPageDto, CustomPageService, CustomPageUpsertDto, MenuItemDto, MenuItemService, RoleDto, RoleService, UserDto } from 'src/app/shared/generated';
+import { CustomPageDto, CustomPageService, CustomPageUpsertDto, MenuItemDto, MenuItemService, RoleDto, RoleService } from 'src/app/shared/generated';
 import { RoleEnum } from 'src/app/shared/generated/enum/role-enum';
 import { Alert } from 'src/app/shared/models/alert';
 import { AlertContext } from 'src/app/shared/models/enums/alert-context.enum';

--- a/Nebula.Web/src/app/pages/disclaimer/disclaimer.component.ts
+++ b/Nebula.Web/src/app/pages/disclaimer/disclaimer.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, ActivatedRoute } from '@angular/router';
 import { AuthenticationService } from 'src/app/services/authentication.service'
-import { UserDto, UserService } from 'src/app/shared/generated';
+import { UserService } from 'src/app/shared/generated';
 import { CustomRichTextTypeEnum } from 'src/app/shared/generated/enum/custom-rich-text-type-enum';
 
 @Component({

--- a/Nebula.Web/src/app/pages/diversion-scenario/diversion-scenario.component.ts
+++ b/Nebula.Web/src/app/pages/diversion-scenario/diversion-scenario.component.ts
@@ -37,7 +37,7 @@ export class DiversionScenarioComponent implements OnInit {
   public richTextTypeID = CustomRichTextTypeEnum.DiversionScenario;
   public defaultSelectedMapFilter = SiteFilterEnum.HasDischarge;
 
-  public vegaSpec = signal<Object>(null);
+  public vegaSpec = signal<object>(null);
 
   public hydstraWeatherConditions: HydstraWeatherCondition[] = HydstraWeatherCondition.all();
 

--- a/Nebula.Web/src/app/pages/field-definition-list/field-definition-list.component.ts
+++ b/Nebula.Web/src/app/pages/field-definition-list/field-definition-list.component.ts
@@ -5,7 +5,7 @@ import { LinkRendererComponent } from 'src/app/shared/components/ag-grid/link-re
 import { ColDef } from 'ag-grid-community';
 import { AgGridAngular } from 'ag-grid-angular';
 import { CustomRichTextTypeEnum } from 'src/app/shared/generated/enum/custom-rich-text-type-enum';
-import { FieldDefinitionDto, FieldDefinitionService, UserDto } from 'src/app/shared/generated';
+import { FieldDefinitionDto, FieldDefinitionService } from 'src/app/shared/generated';
 
 @Component({
     selector: 'nebula-field-definition-list',

--- a/Nebula.Web/src/app/pages/home/home-index/home-index.component.ts
+++ b/Nebula.Web/src/app/pages/home/home-index/home-index.component.ts
@@ -1,10 +1,8 @@
 import { Component, inject } from '@angular/core';
 import { AuthenticationService } from 'src/app/services/authentication.service';
-import { environment } from 'src/environments/environment';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CustomRichTextTypeEnum } from 'src/app/shared/generated/enum/custom-rich-text-type-enum';
 import { RoleEnum } from 'src/app/shared/generated/enum/role-enum';
-import { UserDto } from 'src/app/shared/generated';
 
 @Component({
   selector: 'app-home-index',

--- a/Nebula.Web/src/app/pages/paired-regression-analysis/paired-regression-analysis.component.ts
+++ b/Nebula.Web/src/app/pages/paired-regression-analysis/paired-regression-analysis.component.ts
@@ -38,7 +38,7 @@ export class PairedRegressionAnalysisComponent implements OnInit {
 
   public richTextTypeID = CustomRichTextTypeEnum.PairedRegressionAnalysis;
 
-  public vegaSpec = signal<Object>(null);
+  public vegaSpec = signal<object>(null);
 
   public hydstraIntervals: HydstraInterval[] = HydstraInterval.all();
   public hydstraWeatherConditions: HydstraWeatherCondition[] = HydstraWeatherCondition.all();

--- a/Nebula.Web/src/app/pages/time-series-analysis/time-series-analysis.component.ts
+++ b/Nebula.Web/src/app/pages/time-series-analysis/time-series-analysis.component.ts
@@ -37,7 +37,7 @@ export class TimeSeriesAnalysisComponent implements OnInit {
 
   public richTextTypeID = CustomRichTextTypeEnum.TimeSeriesAnalysis;
 
-  public vegaSpec = signal<Object>(null);
+  public vegaSpec = signal<object>(null);
 
   public hydstraAggregationMethods: HydstraAggregationMethod[] = Object.values(HydstraAggregationMethod);
   public hydstraIntervals: HydstraInterval[] = Object.values(HydstraInterval);

--- a/Nebula.Web/src/app/pages/watershed-detail/watershed-detail.component.ts
+++ b/Nebula.Web/src/app/pages/watershed-detail/watershed-detail.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, ActivatedRoute } from '@angular/router';
 import { AuthenticationService } from 'src/app/services/authentication.service';
 import { forkJoin } from 'rxjs';
-import { UserDto, WatershedDto, WatershedService } from 'src/app/shared/generated';
+import { WatershedDto, WatershedService } from 'src/app/shared/generated';
 
 @Component({
     selector: 'template-watershed-detail',

--- a/Nebula.Web/src/app/services/authentication.service.ts
+++ b/Nebula.Web/src/app/services/authentication.service.ts
@@ -1,19 +1,18 @@
-import { inject, Injectable, signal } from "@angular/core";
-import { toObservable } from "@angular/core/rxjs-interop";
-import { AuthService } from "@auth0/auth0-angular";
+import { inject, Injectable, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { AuthService } from '@auth0/auth0-angular';
 import { AlertService } from '../shared/services/alert.service';
 import { Alert } from '../shared/models/alert';
 import { AlertContext } from '../shared/models/enums/alert-context.enum';
-import { Observable, of } from "rxjs";
-import { catchError, switchMap, } from "rxjs/operators";
+import { Observable, of } from 'rxjs';
+import { catchError, switchMap, } from 'rxjs/operators';
 import { UserDto, UserService } from '../shared/generated';
-import { Router } from "@angular/router";
-import { RoleEnum } from "../shared/generated/enum/role-enum";
-import { environment } from 'src/environments/environment';
-import { HttpErrorResponse } from "@angular/common/http";
+import { Router } from '@angular/router';
+import { RoleEnum } from '../shared/generated/enum/role-enum';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Injectable({
-  providedIn: "root",
+  providedIn: 'root',
 })
 export class AuthenticationService {
   protected auth = inject(AuthService);
@@ -45,7 +44,7 @@ export class AuthenticationService {
           // user and no message -- which is how a 500 on this endpoint presented.
           return this.userService.userClaimsPost().pipe(
             catchError((error) => {
-              console.error("Failed to load user claims:", error);
+              console.error('Failed to load user claims:', error);
               // Auth0 authenticated us, but without an app account there is no
               // usable session -- so report unauthenticated rather than leave
               // hasClaims true with a null currentUser, which showed the
@@ -54,7 +53,7 @@ export class AuthenticationService {
               // control was never affected; this only realigns the chrome.
               this.hasClaims = false;
               this.alertService.pushAlert(new Alert(
-                "We could not load your account. Please try signing in again, or contact support if this continues.",
+                'We could not load your account. Please try signing in again, or contact support if this continues.',
                 AlertContext.Danger));
               return of(null);
             }),
@@ -67,7 +66,7 @@ export class AuthenticationService {
       );
 
     this.auth.error$.subscribe((err: HttpErrorResponse) => {
-      console.error("Auth0 Error:", err);
+      console.error('Auth0 Error:', err);
       this.alertService.pushAlert(new Alert(`An error occurred during authentication: ${err.message}`, AlertContext.Danger));
     });
   }
@@ -168,7 +167,7 @@ export class AuthenticationService {
   }
 
   public createAccount() {
-    this.auth.loginWithRedirect({ authorizationParams: { screen_hint: "signup" } } as any);
+    this.auth.loginWithRedirect({ authorizationParams: { screen_hint: 'signup' } } as any);
   }
 
   public getAuthRedirectUrl() {

--- a/Nebula.Web/src/app/services/lyra.service.ts
+++ b/Nebula.Web/src/app/services/lyra.service.ts
@@ -21,36 +21,36 @@ export class LyraService {
     return this.http.get(route);
   }
 
-  getTimeSeriesAnalysisPlot(multiVariableMultiSiteObject: Object) : Observable<any> {
+  getTimeSeriesAnalysisPlot(multiVariableMultiSiteObject: object) : Observable<any> {
     const route = `${this.baseRoute}/api/plot/multi_variable?json=${JSON.stringify(multiVariableMultiSiteObject)}`;
     return this.http.get(route);
   }
 
-  downloadTimeSeriesAnalysisData(multiVariableMultiSiteObject: Object) {
+  downloadTimeSeriesAnalysisData(multiVariableMultiSiteObject: object) {
     const route = `${this.baseRoute}/api/plot/multi_variable/data?f=csv&json=${JSON.stringify(multiVariableMultiSiteObject)}`;
     return this.http.get(route, {
       responseType: 'arraybuffer'
     });
   }
 
-  getRegressionPlot(regressionObject: Object) : Observable<any> {
+  getRegressionPlot(regressionObject: object) : Observable<any> {
     const route = `${this.baseRoute}/api/plot/regression?json=${JSON.stringify(regressionObject)}`;
     return this.http.get(route);
   }
 
-  downloadRegressionData(regressionObject: Object) {
+  downloadRegressionData(regressionObject: object) {
     const route = `${this.baseRoute}/api/plot/regression/data?f=csv&json=${JSON.stringify(regressionObject)}`;
     return this.http.get(route, {
       responseType: 'arraybuffer'
     });
   }
 
-  getDiversionScenarioPlot(diversionScenarioObject: Object) : Observable<any> {
+  getDiversionScenarioPlot(diversionScenarioObject: object) : Observable<any> {
     const route = `${this.baseRoute}/api/plot/diversion_scenario?json=${JSON.stringify(diversionScenarioObject)}`;
     return this.http.get(route);
   }
 
-  downloadDiversionScenarioData(diversionScenarioObject: Object) {
+  downloadDiversionScenarioData(diversionScenarioObject: object) {
     const route = `${this.baseRoute}/api/plot/diversion_scenario/data?f=csv&json=${JSON.stringify(diversionScenarioObject)}`;
     return this.http.get(route, {
       responseType: 'arraybuffer'

--- a/Nebula.Web/src/app/shared/components/custom-rich-text/custom-rich-text.component.ts
+++ b/Nebula.Web/src/app/shared/components/custom-rich-text/custom-rich-text.component.ts
@@ -3,7 +3,7 @@ import { AuthenticationService } from 'src/app/services/authentication.service';
 import { AlertService } from '../../services/alert.service';
 import { Alert } from '../../models/alert';
 import { AlertContext } from '../../models/enums/alert-context.enum';
-import { CustomRichTextDto, CustomRichTextService, UserDto } from '../../generated';
+import { CustomRichTextDto, CustomRichTextService } from '../../generated';
 import { EditorComponent } from '@tinymce/tinymce-angular';
 
 @Component({

--- a/Nebula.Web/src/app/shared/components/field-definition/field-definition.component.ts
+++ b/Nebula.Web/src/app/shared/components/field-definition/field-definition.component.ts
@@ -5,7 +5,7 @@ import { AlertService } from '../../services/alert.service';
 import { AlertContext } from '../../models/enums/alert-context.enum';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap';
 import { FieldDefinitionTypeEnum } from '../../generated/enum/field-definition-type-enum';
-import { FieldDefinitionDto, FieldDefinitionService, UserDto } from '../../generated';
+import { FieldDefinitionDto, FieldDefinitionService } from '../../generated';
 
 declare let $: any
 

--- a/Nebula.Web/src/app/shared/components/header-nav/header-nav.component.ts
+++ b/Nebula.Web/src/app/shared/components/header-nav/header-nav.component.ts
@@ -6,7 +6,7 @@ import { Alert } from '../../models/alert';
 import { AlertContext } from '../../models/enums/alert-context.enum';
 import { Router } from '@angular/router';
 import { RoleEnum } from '../../generated/enum/role-enum';
-import { CustomPageService, CustomPageWithRolesDto, UserDto, UserService } from '../../generated';
+import { CustomPageService, CustomPageWithRolesDto, UserService } from '../../generated';
 
 @Component({
   selector: 'header-nav',

--- a/Nebula.Web/src/app/shared/components/station-select-card/station-select-card.component.ts
+++ b/Nebula.Web/src/app/shared/components/station-select-card/station-select-card.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, signal } from '@angular/core';
+import { ApplicationRef, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, signal, AfterViewInit } from '@angular/core';
 import { SiteFilterEnum } from '../../models/enums/site-filter.enum';
 import { SiteVariable } from '../../models/site-variable';
 import * as L from 'leaflet';
@@ -24,7 +24,7 @@ declare let $: any;
     styleUrls: ['./station-select-card.component.scss'],
     standalone: false
 })
-export class StationSelectCardComponent implements OnInit {
+export class StationSelectCardComponent implements OnInit, AfterViewInit {
   @ViewChild('mapDiv') mapElement: ElementRef;
 
   @Input()

--- a/Nebula.Web/src/app/shared/interceptors/httpErrorInterceptor.ts
+++ b/Nebula.Web/src/app/shared/interceptors/httpErrorInterceptor.ts
@@ -33,14 +33,12 @@ export class HttpErrorInterceptor implements HttpInterceptor {
 
           // If the backend indicates a missing refresh token, log which request triggered it.
           try {
-            if (typeof error.error === "string" && error.error.indexOf("missing_refresh_token") !== -1) {
-              // eslint-disable-next-line no-console
-              console.error("[HttpErrorInterceptor] Request triggered missing_refresh_token", {
+            if (typeof error.error === 'string' && error.error.indexOf('missing_refresh_token') !== -1) {
+              console.error('[HttpErrorInterceptor] Request triggered missing_refresh_token', {
                 method: request.method,
                 url: request.urlWithParams,
               });
-              // eslint-disable-next-line no-console
-              console.error("[HttpErrorInterceptor] Full HttpErrorResponse:", error);
+              console.error('[HttpErrorInterceptor] Full HttpErrorResponse:', error);
             }
           } catch (e) { }
 

--- a/Nebula.Web/src/main.ts
+++ b/Nebula.Web/src/main.ts
@@ -8,7 +8,7 @@ if (environment.production) {
 }
 
 // Load config BEFORE bootstrapping
-fetch("/assets/config.json", { credentials: "include" })
+fetch('/assets/config.json', { credentials: 'include' })
   .then(async (res) => {
     if (!res.ok) throw new Error(`Preload failed: ${res.status}`);
     const cfg = await res.json();


### PR DESCRIPTION
Follow-up to #54. `npm run lint-fix` over the new flat config.

**Errors 132 → 86, warnings 356 → 340.** 22 files, all in `Nebula.Web/src`.

## Mostly mechanical

Double → single quotes, and unused imports removed (`UserDto` and similar).

## Two categories worth reading rather than skimming

**`Object` → `object` in 9 signatures** (`no-wrapper-object-types`). A real type change — `object` excludes primitives where `Object` does not. It's the correct type for these (Lyra request payloads, vega specs), and the build confirms nothing relied on the looser form.

**`AppComponent` gained `implements OnInit`**, and `station-select-card` gained `AfterViewInit` (`use-lifecycle-interface`). Declarative only; both already had the hook methods.

## One artifact needed hand-cleanup

`--fix` stripped two now-unused `eslint-disable-next-line no-console` directives in `httpErrorInterceptor.ts` but left **whitespace-only lines with trailing spaces** behind. Removed those lines by hand. The directives were already dead — `no-console` isn't enabled here, and wasn't under `.eslintrc.json` either.

## Not addressed

86 errors remain, led by `no-prototype-builtins` (33) and `template/eqeqeq` (13), then a tail of one-offs. These need judgement per site rather than a codemod, so they're deliberately out of scope.

## Verification

- Build clean
- Signal/`@Input` audit scanners return **the same counts as develop** (10 `@Input` mutations, 2 signal-value mutations) — all pre-existing and untouched here; the nearest is ~460 lines from any edit in that file

🤖 Generated with [Claude Code](https://claude.com/claude-code)