### PR TITLE
Remove the dead layerControlOpen @Input

### DIFF
--- a/Nebula.Web/src/app/shared/components/station-select-card/station-select-card.component.ts
+++ b/Nebula.Web/src/app/shared/components/station-select-card/station-select-card.component.ts
@@ -16,8 +16,6 @@ import './leaflet.topojson.js'
 import { WatershedService } from '../../generated';
 import DateRangeHelpers from 'src/app/shared/helpers/date-range-helpers';
 
-declare let $: any;
-
 @Component({
     selector: 'station-select-card',
     templateUrl: './station-select-card.component.html',
@@ -49,8 +47,6 @@ export class StationSelectCardComponent implements OnInit, AfterViewInit {
   public disableAddingVariables: boolean = false;
   @Input()
   public mapHeight: string = '500px';
-  @Input()
-  public layerControlOpen: boolean = false;
   @Input()
   public defaultMapZoom = 12;
   @Input()
@@ -471,7 +467,6 @@ export class StationSelectCardComponent implements OnInit, AfterViewInit {
 
     //to handle click for select area vs double click for zoom
     this.map.on('click', (event: L.LeafletEvent) => {
-      this.layerControlOpen = false;
       if (dblClickTimer !== null) {
         return;
       }
@@ -484,11 +479,6 @@ export class StationSelectCardComponent implements OnInit, AfterViewInit {
       dblClickTimer = null;
       this.map.zoomIn();
     })
-
-    $('.leaflet-control-layers').hover(
-      () => { this.layerControlOpen = true; },
-      () => { this.layerControlOpen = false; }
-    );
   }
 
   //fitBounds will use it's default zoom level over what is sent in


### PR DESCRIPTION
Investigated the `@Input`-mutation findings from the audit scanners. **Only one was real, and it turned out to be dead code rather than a change-detection bug.**

## What `layerControlOpen` actually was

Written in three places, read in **none** — no template binding, no TypeScript read, and no parent binds it (the three pages hosting `station-select-card` never set it). It has been inert state.

Removed the `@Input` and all three writes. The jQuery hover registration went with them, since setting this flag was all it did:

```ts
$('.leaflet-control-layers').hover(
  () => { this.layerControlOpen = true; },
  () => { this.layerControlOpen = false; }
);
```

That was the file's only jQuery call, so `declare let $: any;` is now dead too and is removed. Verified no remaining `$` usage of any form in the file.

## The other findings were false positives

Left alone, deliberately:

- **`ng-select-custom` and `station-select-card:622`** — the scanner matched `==` comparisons (`if (this.control == null || ...)`), not assignments.
- **`this.timeseries().push(...)`** in the two analysis pages — this is `UntypedFormArray.push()`, the correct reactive-forms API. `timeseries()` is a plain method returning a `FormArray`, not a signal, so the `()` only looked like a signal read.

So the scanner's "10 @Input mutations, 2 signal-value mutations" reduces to one dead input. Worth knowing before anyone re-runs those scanners and reads the raw counts as a bug backlog.

## Verification

- Build clean
- 0 references to `layerControlOpen` left in `src`
- Lint unchanged at 86 errors (warnings 340 → 339)

🤖 Generated with [Claude Code](https://claude.com/claude-code)