### PR TITLE
Anchor the "Link to this analysis" popover to its button

### DIFF
--- a/Nebula.Web/src/app/shared/components/link-to-analysis/link-to-analysis.component.html
+++ b/Nebula.Web/src/app/shared/components/link-to-analysis/link-to-analysis.component.html
@@ -5,7 +5,7 @@
     triggers="manual"
     #p="ngbPopover"
     [ngbPopover]="popContent"
-    container="body"
+    placement="top-end top bottom-end bottom"
     (click)="openPopoverAndSelectText()"
 >
     Link to this analysis

--- a/Nebula.Web/src/app/shared/components/link-to-analysis/link-to-analysis.component.html
+++ b/Nebula.Web/src/app/shared/components/link-to-analysis/link-to-analysis.component.html
@@ -5,7 +5,7 @@
     triggers="manual"
     #p="ngbPopover"
     [ngbPopover]="popContent"
-    placement="top-end top bottom-end bottom"
+    [placement]="['top-end', 'top', 'bottom-end', 'bottom']"
     (click)="openPopoverAndSelectText()"
 >
     Link to this analysis

--- a/Nebula.Web/src/app/shared/components/link-to-analysis/link-to-analysis.component.ts
+++ b/Nebula.Web/src/app/shared/components/link-to-analysis/link-to-analysis.component.ts
@@ -38,9 +38,11 @@ export class LinkToAnalysisComponent implements OnInit {
       return;
     }
 
-    this.elem.nativeElement.closest('body')
-      .querySelector('#linkText')
-      .select();
+    // Scoped to this component. The popover used to be appended to body, so
+    // this had to search the whole document for #linkText -- which picks the
+    // first match, not necessarily this component's, and every instance of
+    // this component uses that same id.
+    this.elem.nativeElement.querySelector('#linkText')?.select();
   }
 
 }


### PR DESCRIPTION
The popover was rendering ~300px above the button, over the Selected Data card, with its arrow pointing at nothing.

## Cause

The button declared `container="body"`, which appends the popover to `document.body` instead of leaving it beside the button. Popper positions it relative to the button but within the **body's** layout context, and ng-bootstrap 21 only re-runs that positioning from an `afterEveryRender` hook — which, now that the app is zoneless, fires only when change detection runs.

So anything that shifts layout **without** triggering change detection leaves the popover at a stale document position. The Vega chart is the obvious candidate on these pages: Vega writes into `#vis` directly, outside Angular.

## Fix

- **Dropped `container="body"`** so the popover renders as a sibling of the button and is positioned in the button's own layout context. Verified first that nothing between the button and the page root sets `overflow`, so `body` was not being used to escape a clipping ancestor.
- **Explicit `placement="top-end top bottom-end bottom"`** instead of the default `auto`, so it favours sitting just above the button and falls back downward rather than choosing freely.
- **Scoped the text-selection lookup.** With the popover out of `body`, `selectPopoverText` no longer needs to search the whole document for `#linkText`. It queried from `body` and took the first match — not necessarily this component's, and all three analysis pages instantiate this component with that same hard-coded id. Now scoped to the component's own element and null-safe.

## Please eyeball this one in QA

Build is clean, but **I could not verify this visually** — it's a layout fix and I have no browser here. Worth confirming the popover sits just above the button on all three pages (time-series, paired-regression, diversion-scenario), and that it isn't clipped.

One diagnostic if it still drifts: the **date pickers on these same pages also use `container="body"`** (6 of them). If they show the same displacement, the root cause is the shared zoneless/`afterEveryRender` positioning path rather than anything specific to this component, and the fix belongs at that level instead.

## Note on the diff

The `.ts` file had mixed line endings (41 CRLF, 5 LF); editing normalized it to the file's dominant CRLF, so the `@Component` block shows in the diff with identical content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)