### PR TITLE
Fail loudly when a DB role is missing instead of skipping the grant

### DIFF
--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -443,6 +443,18 @@ stages:
                     foreach ($role in $roles.Split(',')) {
                         $r = $role.Trim()
                         if ($r) {
+                            # Assert the ROLE exists BEFORE testing membership. IS_ROLEMEMBER returns
+                            # NULL for an unknown role, and `NULL = 0` evaluates to UNKNOWN rather than
+                            # TRUE, so a bare `= 0` check skips the grant SILENTLY and still reports
+                            # success. db_executor is created by this repo's own Database project, so a
+                            # DacPac deploy that has not landed yet would leave every db_executor grant
+                            # quietly undone behind a green pipeline.
+                            #
+                            # Checks sys.database_principals with type = 'R' rather than
+                            # DATABASE_PRINCIPAL_ID, which resolves ANY principal (users, application
+                            # roles). A same-named non-role would satisfy that weaker test and then fail
+                            # in ALTER ROLE with a murkier message.
+                            $sql += "`nIF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'$r' AND type = 'R') THROW 50000, 'Database role [$r] does not exist -- deploy the DacPac before granting.', 1;"
                             $sql += "`nIF IS_ROLEMEMBER('$r', N'$principal') = 0 ALTER ROLE [$r] ADD MEMBER [$principal];"
                         }
                     }


### PR DESCRIPTION
The H2O Entra group grant step tests role membership like this:

```sql
IF IS_ROLEMEMBER('db_executor', N'H2O QA Group') = 0
    ALTER ROLE [db_executor] ADD MEMBER [H2O QA Group];
```

`IS_ROLEMEMBER` returns **NULL** for a role that does not exist, and `NULL = 0` evaluates to **UNKNOWN** rather than TRUE. So a missing or misspelled role causes the `ALTER ROLE` to be skipped and the step to report **success** — principals end up ungranted behind a completely green pipeline.

## Why this is live exposure here, not theoretical

This repo grants **`db_executor`**, which is a custom role created by its own Database project (`CREATE ROLE [db_executor]`). Built-in roles like `db_datareader` always exist, so they never trip this. A custom one can be absent — and if the DacPac deploy that creates it has not landed, **every `db_executor` grant in the access matrix is silently dropped**. Since `db_executor` is what lets principals execute stored procedures, the symptom surfaces much later as runtime permission errors, with nothing at deploy time to point at the cause.

## The fix

```sql
IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'db_executor' AND type = 'R')
    THROW 50000, 'Database role [db_executor] does not exist -- deploy the DacPac before granting.', 1;
IF IS_ROLEMEMBER('db_executor', N'H2O QA Group') = 0
    ALTER ROLE [db_executor] ADD MEMBER [H2O QA Group];
```

`sys.database_principals` with `type = 'R'` rather than `DATABASE_PRINCIPAL_ID`, which resolves **any** database principal — users and application roles included — and would let a same-named non-role satisfy the assertion only to fail inside `ALTER ROLE` with a murkier message.

Membership checks stay idempotent. Only the missing-role case changes behaviour: from silent skip to a failure naming the role.

## Provenance

Found while sweeping the Shasta-family repos for this pattern. The same fix has landed in the gold skeleton (esassoc/shasta#72) and the WaveRunup fork (esassoc/wave-runup#88), where Copilot review caught the `DATABASE_PRINCIPAL_ID` refinement. Four family repos share the unguarded form and all four grant a custom `db_executor`; this is one of them.

## Verification

- The inline pipeline PowerShell was extracted from the YAML block and parsed via `[Parser]::ParseInput` — no syntax errors.
- The generated T-SQL was rendered for a real principal/role set and inspected: each `THROW` follows a semicolon-terminated statement, as `THROW` requires.
- `type = 'R'` was confirmed against a live SQL Server rather than from memory:

```
name          type type_desc
db_datareader R    DATABASE_ROLE
db_datawriter R    DATABASE_ROLE
db_ddladmin   R    DATABASE_ROLE
db_owner      R    DATABASE_ROLE
dbo           S    SQL_USER
```

Every role granted by this step is `type = 'R'`; a user such as `dbo` is `type = 'S'`, so the predicate correctly rejects the same-named-user case.

No behavioural change on a healthy deploy — this only converts a silent failure into a loud one.
