### PR TITLE
Stop a duplicate claim from throwing in the user-create path

### DIFF
--- a/Nebula.API/Controllers/UserController.cs
+++ b/Nebula.API/Controllers/UserController.cs
@@ -46,9 +46,11 @@ namespace Nebula.API.Controllers
             var userDto = EFModels.Entities.User.GetByGlobalUserID(_dbContext, globalID) ?? EFModels.Entities.User.GetByEmail(_dbContext, email);  // get by globalid or email
             if (userDto == null)
             {
-                var firstName = claims?.Claims.SingleOrDefault(c => c.Type == ClaimsConstants.GivenName)?.Value;
-                var lastName = claims?.Claims.SingleOrDefault(c => c.Type == ClaimsConstants.FamilyName)?.Value;
-                var loginName = claims?.Claims.SingleOrDefault(c => c.Type == "nickname")?.Value;
+                // FirstOrDefault, not SingleOrDefault: the latter throws on a duplicate claim type,
+                // which an Auth0 Action can produce. Trimmed so "" and "   " behave the same.
+                var firstName = claims?.Claims.FirstOrDefault(c => c.Type == ClaimsConstants.GivenName)?.Value?.Trim();
+                var lastName = claims?.Claims.FirstOrDefault(c => c.Type == ClaimsConstants.FamilyName)?.Value?.Trim();
+                var loginName = claims?.Claims.FirstOrDefault(c => c.Type == "nickname")?.Value?.Trim();
                 var userCreateDto = new UserCreateDto()
                 {
                     FirstName = firstName ?? "First",


### PR DESCRIPTION
Copilot raised a whitespace hole on esassoc/ltinfo#282; sweeping it across the family
turned up this app's remaining SingleOrDefault claim reads, in UserController's create
path. SingleOrDefault THROWS on a duplicate claim type rather than tolerating one, and
that is reachable as soon as an Auth0 Action sets a custom claim which ASP.NET's inbound
mapping also emits -- which the ocstormwatertools Action, shared with neptune, now does.

User.UpdateClaims was already using FirstOrDefault, with a comment explaining exactly
this; the controller had not caught up. Both are consistent now, and the values are
trimmed at read time so "" and "   " behave the same -- an Auth0 Form's `required: true`
accepts spaces, and an untrimmed name would be stored as blanks.

No Action file changes here: this app has no Action of its own. See Build/auth0/README.md
and esassoc/neptune for the shared tenant's copy.

Verified: Nebula.API builds clean. Regenerated swagger.json discarded rather than
committed.

Part of a family-wide sweep. The Action lives in five tenants plus the Shasta skeleton, and all copies shared the untrimmed helpers; the API-side gaps were found by reading each app's claim handling against it. Sibling PRs: esassoc/ltinfo#282 (where Copilot raised it), esassoc/wave-runup#89, and matching branches in the other repos.